### PR TITLE
Setup deploy from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,16 +64,33 @@ jobs:
             npm run test:unit
           working_directory: frontend
 
+  deploy:
+    docker:
+      - image: cimg/base:2023.06
+    steps:
+      - checkout
+      - run: sudo apt-get update && sudo apt-get install -y curl
+      - run: curl -L https://fly.io/install.sh | sh
+      - run: /home/circleci/.fly/bin/flyctl deploy --remote-only
 
 # Orchestrate jobs using workflows
 # See: https://circleci.com/docs/configuration-reference/#workflows
 workflows:
-  backend:
+  test-and-deploy:
     jobs:
       - backend build
       - backend lint
       - backend test
-  frontend:
-    jobs:
       - frontend lint
       - frontend unit test
+      - deploy:
+          requires:
+            - backend build
+            - backend lint
+            - backend test
+            - frontend lint
+            - frontend unit test
+          filters:
+            branches:
+              only:
+                - main


### PR DESCRIPTION
Not 100% sure when I should have different workflows or not, but it looks like you can't define dependencies between workflows, so to ensure that the deploy only runs after testing/linting has completed they all need to be in one big workflow.