### PR TITLE
Accept &str instead of String

### DIFF
--- a/backend/src/api/bunpro/request.rs
+++ b/backend/src/api/bunpro/request.rs
@@ -42,13 +42,13 @@ mod test_super {
     #[test]
     fn test_bunpro_with_reviews() {
         let with_reviews = include_str!("./fixtures/bunpro_with_reviews.json");
-        let response = serialize_response(String::from(with_reviews));
+        let response = serialize_response(with_reviews);
         assert!(response.is_ok());
     }
 
     #[test]
     fn test_bunpro_with_no_reviews() {
         let with_no_reviews = include_str!("./fixtures/bunpro_with_no_reviews.json");
-        assert!(serialize_response(String::from(with_no_reviews)).is_ok());
+        assert!(serialize_response(with_no_reviews).is_ok());
     }
 }

--- a/backend/src/api/wanikani/request.rs
+++ b/backend/src/api/wanikani/request.rs
@@ -44,7 +44,7 @@ mod test_super {
     fn test_can_deserialize_empty_reviews() {
         let response_data = include_str!("./fixtures/wanikani_with_no_reviews.json");
 
-        let response = deserialize_response(response_data.into());
+        let response = deserialize_response(response_data);
 
         assert!(response.is_ok());
     }
@@ -53,7 +53,7 @@ mod test_super {
     fn test_can_deserialize_with_reviews() {
         let response_data = include_str!("./fixtures/wanikani_with_reviews.json");
 
-        let response = deserialize_response(response_data.into());
+        let response = deserialize_response(response_data);
 
         assert!(response.is_ok());
     }


### PR DESCRIPTION
Following https://rust-unofficial.github.io/patterns/idioms/coercion-arguments.html (and an explanation from a colleague), using `&str` instead of `String` in the method args creates a more flexible API.