### PR TITLE
Convert cache key into an enum

### DIFF
--- a/backend/src/api/anki/request.rs
+++ b/backend/src/api/anki/request.rs
@@ -5,7 +5,10 @@ use axum::{extract::State, Json};
 use reqwest::{Client, StatusCode};
 use scraper::{Html, Selector};
 
-use crate::api::{cacheable::Cacheable, internal_error, ErrorResponse};
+use crate::api::{
+    cacheable::{CacheKey, Cacheable},
+    internal_error, ErrorResponse,
+};
 
 use super::data::AnkiData;
 
@@ -19,8 +22,8 @@ pub async fn anki_handler(
 
 #[async_trait]
 impl Cacheable for AnkiData {
-    fn cache_key() -> String {
-        "anki_data".into()
+    fn cache_key() -> CacheKey {
+        CacheKey::Anki
     }
 
     fn ttl() -> usize {

--- a/backend/src/api/bunpro/request.rs
+++ b/backend/src/api/bunpro/request.rs
@@ -4,7 +4,10 @@ use async_trait::async_trait;
 use axum::{extract::State, Json};
 use reqwest::{Client, StatusCode};
 
-use crate::api::{cacheable::Cacheable, internal_error, ErrorResponse};
+use crate::api::{
+    cacheable::{CacheKey, Cacheable},
+    internal_error, ErrorResponse,
+};
 
 use super::data::{BunproData, StudyQueue};
 
@@ -20,8 +23,8 @@ pub async fn bunpro_handler(
 
 #[async_trait]
 impl Cacheable for BunproData {
-    fn cache_key() -> String {
-        "bunpro_data".into()
+    fn cache_key() -> CacheKey {
+        CacheKey::Bunpro
     }
 
     fn ttl() -> usize {

--- a/backend/src/api/satori/request.rs
+++ b/backend/src/api/satori/request.rs
@@ -5,7 +5,10 @@ use axum::{extract::State, Json};
 use reqwest::{Client, StatusCode};
 use tokio::try_join;
 
-use crate::api::{cacheable::Cacheable, internal_error, ErrorResponse};
+use crate::api::{
+    cacheable::{CacheKey, Cacheable},
+    internal_error, ErrorResponse,
+};
 
 use super::data::{SatoriCurrentCardsResponse, SatoriData, SatoriNewCardsResponse};
 
@@ -21,8 +24,8 @@ pub async fn satori_handler(
 
 #[async_trait]
 impl Cacheable for SatoriData {
-    fn cache_key() -> String {
-        "satori_data".into()
+    fn cache_key() -> CacheKey {
+        CacheKey::Satori
     }
 
     fn ttl() -> usize {

--- a/backend/src/api/wanikani/request.rs
+++ b/backend/src/api/wanikani/request.rs
@@ -4,7 +4,10 @@ use async_trait::async_trait;
 use axum::{extract::State, http::StatusCode, Json};
 use reqwest::Client;
 
-use crate::api::{cacheable::Cacheable, internal_error, ErrorResponse};
+use crate::api::{
+    cacheable::{CacheKey, Cacheable},
+    internal_error, ErrorResponse,
+};
 
 use super::data::{WanikaniData, WanikaniSummaryResponse};
 
@@ -21,8 +24,8 @@ pub async fn wanikani_handler(
 
 #[async_trait]
 impl Cacheable for WanikaniData {
-    fn cache_key() -> String {
-        "wanikani_data".into()
+    fn cache_key() -> CacheKey {
+        CacheKey::Wanikani
     }
 
     fn ttl() -> usize {


### PR DESCRIPTION
I'm planning to add a script to be able to bust the cache in dev, and to make that easier I want to have all the keys easily enumerable, to make it easy to keep the script in sync if I ever add extra options.