### PR TITLE
Move caching to the individual request level

### DIFF
--- a/backend/src/api/anki/request.rs
+++ b/backend/src/api/anki/request.rs
@@ -15,7 +15,7 @@ use super::data::AnkiData;
 pub async fn anki_handler(
     State(redis_client): State<Option<redis::Client>>,
 ) -> Result<Json<AnkiData>, (StatusCode, Json<ErrorResponse>)> {
-    let anki_data = AnkiData::get(redis_client).await.map_err(internal_error)?;
+    let anki_data = AnkiData::get(&redis_client).await.map_err(internal_error)?;
 
     Ok(Json(anki_data))
 }

--- a/backend/src/api/bunpro/request.rs
+++ b/backend/src/api/bunpro/request.rs
@@ -14,7 +14,7 @@ use super::data::{BunproData, StudyQueue};
 pub async fn bunpro_handler(
     State(redis_client): State<Option<redis::Client>>,
 ) -> Result<Json<BunproData>, (StatusCode, Json<ErrorResponse>)> {
-    let bunpro_data = BunproData::get(redis_client)
+    let bunpro_data = BunproData::get(&redis_client)
         .await
         .map_err(internal_error)?;
 

--- a/backend/src/api/cacheable.rs
+++ b/backend/src/api/cacheable.rs
@@ -42,8 +42,8 @@ pub trait Cacheable: DeserializeOwned + serde::Serialize + Clone {
     fn ttl() -> usize;
     async fn api_fetch() -> anyhow::Result<Self>;
 
-    async fn get(redis_client: Option<redis::Client>) -> anyhow::Result<Self> {
-        let cache_data = Self::cache_read(&redis_client).await;
+    async fn get(redis_client: &Option<redis::Client>) -> anyhow::Result<Self> {
+        let cache_data = Self::cache_read(redis_client).await;
 
         if let Some(cache_data) = cache_data {
             return Ok(cache_data);
@@ -55,7 +55,7 @@ pub trait Cacheable: DeserializeOwned + serde::Serialize + Clone {
         //  future cannot be sent between threads safely
         {
             let cloned_data = api_data.clone();
-            let write_result = Self::cache_write(&redis_client, cloned_data).await;
+            let write_result = Self::cache_write(redis_client, cloned_data).await;
             let _ = write_result.map_err(Self::cache_log);
         }
 

--- a/backend/src/api/cacheable.rs
+++ b/backend/src/api/cacheable.rs
@@ -6,7 +6,8 @@ use redis::{AsyncCommands, RedisError, ToRedisArgs};
 use serde::de::DeserializeOwned;
 
 pub enum CacheKey {
-    Wanikani,
+    WanikaniSummary,
+    WanikaniStats,
     Bunpro,
     Satori,
     Anki,
@@ -15,7 +16,8 @@ pub enum CacheKey {
 impl Display for CacheKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let cache_key = match self {
-            CacheKey::Wanikani => "wanikani_data",
+            CacheKey::WanikaniSummary => "wanikani_summary_data",
+            CacheKey::WanikaniStats => "wanikani_stats_data",
             CacheKey::Bunpro => "bunpro_data",
             CacheKey::Satori => "satori_data",
             CacheKey::Anki => "anki_data",

--- a/backend/src/api/satori/request.rs
+++ b/backend/src/api/satori/request.rs
@@ -15,7 +15,7 @@ use super::data::{SatoriCurrentCardsResponse, SatoriData, SatoriNewCardsResponse
 pub async fn satori_handler(
     State(redis_client): State<Option<redis::Client>>,
 ) -> Result<Json<SatoriData>, (StatusCode, Json<ErrorResponse>)> {
-    let satori_data = SatoriData::get(redis_client)
+    let satori_data = SatoriData::get(&redis_client)
         .await
         .map_err(internal_error)?;
 

--- a/backend/src/api/wanikani/data.rs
+++ b/backend/src/api/wanikani/data.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 
-#[derive(serde::Deserialize)]
+#[derive(serde::Deserialize, serde::Serialize, Clone)]
 pub struct WanikaniSummaryResponse {
     data_updated_at: DateTime<Utc>,
     data: SummaryDataStructure,
@@ -14,7 +14,7 @@ impl WanikaniSummaryResponse {
     }
 }
 
-#[derive(serde::Deserialize)]
+#[derive(serde::Deserialize, serde::Serialize, Clone)]
 pub struct SummaryDataStructure {
     lessons: Vec<Lesson>,
     reviews: Vec<Review>,
@@ -37,7 +37,7 @@ impl SummaryDataStructure {
     }
 }
 
-#[derive(serde::Deserialize)]
+#[derive(serde::Deserialize, serde::Serialize, Clone)]
 struct Lesson {
     subject_ids: Vec<u32>,
 }
@@ -50,7 +50,7 @@ impl Lesson {
 
 type Review = Lesson;
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
 pub struct WanikaniReviewStats {
     total_count: u32,
 }
@@ -67,7 +67,7 @@ impl WanikaniReviewStats {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(serde::Serialize)]
 pub struct WanikaniData {
     data_updated_at: DateTime<Utc>,
     active_lesson_count: u32,

--- a/backend/src/api/wanikani/request.rs
+++ b/backend/src/api/wanikani/request.rs
@@ -17,8 +17,8 @@ pub async fn wanikani_handler(
     State(redis_client): State<Option<redis::Client>>,
 ) -> Result<Json<WanikaniData>, (StatusCode, Json<ErrorResponse>)> {
     let (summary_response, stats_response) = try_join!(
-        WanikaniSummaryResponse::get(redis_client.clone()),
-        WanikaniReviewStats::get(redis_client.clone())
+        WanikaniSummaryResponse::get(&redis_client),
+        WanikaniReviewStats::get(&redis_client)
     )
     .map_err(internal_error)?;
 


### PR DESCRIPTION
I want to be able to apply different TTLs to the redis keys based on the data, so the first step is to cache the individual requests, instead of the data sent to the frontend.

In theory this will make the APIs slower, but it should in the range of milliseconds, so it shouldn't be noticeable.