### PR TITLE
Include learning cards in active review count

### DIFF
--- a/backend/src/api/anki/data.rs
+++ b/backend/src/api/anki/data.rs
@@ -14,9 +14,62 @@ impl From<DeckInfo> for AnkiData {
         deck.review_card_count();
 
         Self {
-            active_review_count: deck.review_card_count(),
+            active_review_count: deck.review_card_count() + deck.learn_count(),
             new_card_count: deck.new_card_count(),
             data_updated_at: Utc::now(),
         }
+    }
+}
+
+#[cfg(test)]
+mod test_super {
+    use super::*;
+
+    fn create_deck_info(
+        review_card_count: Option<u32>,
+        learn_count: Option<u32>,
+        new_card_count: Option<u32>,
+    ) -> DeckInfo {
+        DeckInfo {
+            deck_id: 1,
+            deck_name: String::from("Japanese"),
+            level: 3,
+            review_card_count,
+            learn_count,
+            new_card_count,
+            uncapped_new_card_count: None,
+            uncapped_review_card_count: None,
+            total_card_count: 10,
+        }
+    }
+
+    #[test]
+    fn test_create_anki_data_with_no_reviews_or_new_cards() {
+        let deck_info = create_deck_info(None, None, None);
+
+        let anki_data: AnkiData = AnkiData::from(deck_info);
+
+        assert_eq!(anki_data.active_review_count, 0);
+        assert_eq!(anki_data.new_card_count, 0);
+    }
+
+    #[test]
+    fn test_create_anki_data_with_reviews_and_new_cards() {
+        let deck_info = create_deck_info(Some(10), None, Some(5));
+
+        let anki_data: AnkiData = AnkiData::from(deck_info);
+
+        assert_eq!(anki_data.active_review_count, 10);
+        assert_eq!(anki_data.new_card_count, 5);
+    }
+
+    #[test]
+    fn test_create_anki_data_with_learning_and_review_cards() {
+        let deck_info = create_deck_info(Some(10), Some(10), None);
+
+        let anki_data = AnkiData::from(deck_info);
+
+        assert_eq!(anki_data.active_review_count, 20);
+        assert_eq!(anki_data.new_card_count, 0);
     }
 }

--- a/backend/src/api/anki/fixtures/protobuf_with_review_and_learning_cards
+++ b/backend/src/api/anki/fixtures/protobuf_with_review_and_learning_cards
@@ -1,0 +1,1 @@
+CiQaHgiu0+H8wy4SCEphcGFuZXNlIAEwBjgISAhgBmjCKTAGOAgQrtPh/MMuGICAmwQ=

--- a/backend/src/api/anki/request.rs
+++ b/backend/src/api/anki/request.rs
@@ -130,4 +130,28 @@ mod test_super {
         assert_eq!(japanese_deck.review_card_count(), 0);
         assert_eq!(japanese_deck.new_card_count(), 0);
     }
+
+    #[test]
+    fn test_can_decode_protobuf_message_with_learning_count() {
+        let encoded_message = include_str!("./fixtures/protobuf_with_review_and_learning_cards");
+        let decoded_message = general_purpose::STANDARD
+            .decode(encoded_message)
+            .expect("base64 decode failed");
+
+        let deck_list_response = decode_protobuf_response(Bytes::from(decoded_message));
+
+        assert!(deck_list_response.is_ok());
+
+        let decks = deck_list_response
+            .unwrap()
+            .all_decks_info
+            .expect("deck lists was empty")
+            .decks;
+        assert_eq!(decks.len(), 1);
+
+        let japanese_deck = decks.first().unwrap();
+
+        assert_eq!(japanese_deck.review_card_count(), 6);
+        assert_eq!(japanese_deck.learn_count(), 8);
+    }
 }


### PR DESCRIPTION
It looks like when you get a card wrong it gets marked as learning, so the total to review was off.