### PR TITLE
Return Error when request is a non-success code

### DIFF
--- a/backend/src/api/anki/request.rs
+++ b/backend/src/api/anki/request.rs
@@ -50,6 +50,7 @@ async fn get_decks_data() -> anyhow::Result<DeckInfo> {
         .header("Content-Type", "application/octet-stream")
         .send()
         .await?
+        .error_for_status()?
         .bytes()
         .await?;
 

--- a/backend/src/api/bunpro/request.rs
+++ b/backend/src/api/bunpro/request.rs
@@ -42,6 +42,7 @@ impl Cacheable for BunproData {
             .get(url)
             .send()
             .await?
+            .error_for_status()?
             .text()
             .await
             .map(|body| Self::serialize_response(&body))??;

--- a/backend/src/api/satori/request.rs
+++ b/backend/src/api/satori/request.rs
@@ -46,6 +46,7 @@ async fn get_current_cards() -> anyhow::Result<SatoriCurrentCardsResponse> {
         .get("https://www.satorireader.com/api/studylist/due/count")
         .send()
         .await?
+        .error_for_status()?
         .text()
         .await
         .map(|body| serialize_current_cards_response(&body))?

--- a/backend/src/api/wanikani/request.rs
+++ b/backend/src/api/wanikani/request.rs
@@ -44,6 +44,7 @@ impl Cacheable for WanikaniSummaryResponse {
             .get("https://api.wanikani.com/v2/summary")
             .send()
             .await?
+            .error_for_status()?
             .text()
             .await
             .map(|body| Self::try_from_response_body(&body))?
@@ -68,6 +69,7 @@ impl Cacheable for WanikaniReviewStats {
             .get(url)
             .send()
             .await?
+            .error_for_status()?
             .text()
             .await
             .map(|body| Self::try_from_response_body(&body))?


### PR DESCRIPTION
By default reqwest doesn't return an error on a non success code, but the `error_for_status` method returns an error if the status code is a non 200.

Since every response is being deserliazed by serde this doesn't change behaviour, as serde would likely fail anyway, but this makes the reason clearer