### PR TITLE
Cache request time

### DIFF
--- a/backend/src/api/bunpro/data.rs
+++ b/backend/src/api/bunpro/data.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 pub struct StudyQueue {
     user_information: UserInformation,
     requested_information: StudyQueueData,
+    pub fetched_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -25,7 +26,7 @@ impl BunproData {
         let todays_stats = stats.count_for(today.naive_local().date());
 
         Self {
-            data_updated_at: Utc::now(),
+            data_updated_at: study_queue.fetched_at.unwrap_or(Utc::now()),
             active_review_count: study_queue.requested_information.reviews_available,
             daily_study_goal_met: todays_stats > 0,
         }

--- a/backend/src/api/bunpro/request.rs
+++ b/backend/src/api/bunpro/request.rs
@@ -2,6 +2,7 @@ use std::env;
 
 use async_trait::async_trait;
 use axum::{extract::State, Json};
+use chrono::Utc;
 use reqwest::{Client, StatusCode};
 use tokio::try_join;
 
@@ -60,7 +61,9 @@ impl Cacheable for StudyQueue {
 }
 
 fn serialize_response(body: &str) -> anyhow::Result<StudyQueue> {
-    let json = serde_json::from_str(body)?;
+    let mut json: StudyQueue = serde_json::from_str(body)?;
+
+    json.fetched_at = Some(Utc::now());
 
     Ok(json)
 }

--- a/backend/src/api/satori/data.rs
+++ b/backend/src/api/satori/data.rs
@@ -15,7 +15,7 @@ impl SatoriData {
         stats: SatoriStats,
     ) -> Self {
         Self {
-            data_updated_at: Utc::now(),
+            data_updated_at: current_cards.fetched_at.unwrap_or(Utc::now()),
             active_review_count: current_cards.result,
             new_card_count: new_cards.result,
             daily_study_goal_met: stats.heat_level == SatoriHeatLevel::Four,
@@ -29,6 +29,7 @@ pub struct SatoriCurrentCardsResponse {
     success: bool,
     message: Option<String>,
     exception: Option<String>,
+    pub fetched_at: Option<DateTime<Utc>>,
 }
 
 #[derive(serde::Deserialize, serde::Serialize, Clone)]

--- a/backend/src/api/satori/request/current_cards.rs
+++ b/backend/src/api/satori/request/current_cards.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use chrono::Utc;
 
 use crate::api::{
     cacheable::{CacheKey, Cacheable},
@@ -36,7 +37,9 @@ async fn get_current_cards() -> anyhow::Result<SatoriCurrentCardsResponse> {
 }
 
 fn serialize_current_cards_response(body: &str) -> anyhow::Result<SatoriCurrentCardsResponse> {
-    let json_data: SatoriCurrentCardsResponse = serde_json::from_str(body)?;
+    let mut json_data: SatoriCurrentCardsResponse = serde_json::from_str(body)?;
+
+    json_data.fetched_at = Some(Utc::now());
 
     Ok(json_data)
 }


### PR DESCRIPTION
When I added the extra requests for Satori and Bunpro I didn't cache the request time, so it always shows up as the time of the browser request.