### PR TITLE
Switch to separate token and fetch auth header via login

### DIFF
--- a/.env.development.sample
+++ b/.env.development.sample
@@ -1,5 +1,5 @@
 WANIKANI_API_TOKEN="<Token goes here>"
 BUNPRO_API_TOKEN="<Token goes here>"
-BUNPRO_COOKIE="<Cookie goes here>"
+BUNPRO_GRAMMAR_COOKIE="<Cookie goes here>"
 SATORI_COOKIE="<Cookie goes here>"
 ANKIWEB_COOKIE="<Cookie goes here>"

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -206,6 +206,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d606d0fba62e13cf04db20536c05cb7f13673c161cb47a47a82b9b9e7d3f1daa"
+dependencies = [
+ "cookie",
+ "idna 0.2.3",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +271,12 @@ dependencies = [
  "quote",
  "syn 2.0.23",
 ]
+
+[[package]]
+name = "deranged"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 
 [[package]]
 name = "derive_more"
@@ -553,6 +587,27 @@ dependencies = [
 
 [[package]]
 name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
@@ -691,6 +746,12 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
@@ -970,6 +1031,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a8c1bda5ae1af7f99a2962e49df150414a43d62404644d98dd5c3a93d07457"
+dependencies = [
+ "idna 0.3.0",
+ "psl-types",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,6 +1170,8 @@ checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
  "base64",
  "bytes",
+ "cookie",
+ "cookie_store",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -1503,6 +1582,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a79d09ac6b08c1ab3906a2f7cc2e81a0e27c7ae89c63812df75e52bef0751e07"
+dependencies = [
+ "deranged",
+ "itoa",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c65469ed6b3a4809d987a41eb1dc918e9bc1d92211cbad7ae82931846f7451"
+dependencies = [
+ "time-core",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,7 +1855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.4.0",
  "percent-encoding",
 ]
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -15,7 +15,7 @@ indexmap = "2.0.0"
 prost = "0.11.9"
 redis = { version = "0.23.0", features = ["serde_json", "tls-rustls", "tokio-comp", "tokio-rustls-comp"] }
 regex = "1.10.2"
-reqwest = { version = "0.11.18", default-features = false, features = ["serde_json", "json", "rustls-tls"] }
+reqwest = { version = "0.11.18", default-features = false, features = ["serde_json", "json", "rustls-tls", "cookies"] }
 scraper = { version = "0.17.1", features = ["indexmap"] }
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.99"

--- a/backend/src/api/bunpro/request/stats.rs
+++ b/backend/src/api/bunpro/request/stats.rs
@@ -37,7 +37,9 @@ fn bunpro_stats_client(frontend_session_token: String) -> anyhow::Result<Client>
     let mut headers = reqwest::header::HeaderMap::new();
     headers.insert(
         header::AUTHORIZATION,
-        format!("Token {}", frontend_session_token).parse().unwrap(),
+        format!("Token token={}", frontend_session_token)
+            .parse()
+            .unwrap(),
     );
 
     Ok(Client::builder().default_headers(headers).build()?)
@@ -73,7 +75,7 @@ async fn get_frontend_auth_token() -> anyhow::Result<String> {
         }
     });
 
-    cookie.ok_or(anyhow!("frontend_app_session cookie could not be found"))
+    cookie.ok_or(anyhow!(format!("{} cookie could not be found", TOKEN_NAME)))
 }
 
 fn serialize_stats_response(body: String) -> anyhow::Result<BunproReviewStats> {

--- a/backend/src/api/bunpro/request/stats.rs
+++ b/backend/src/api/bunpro/request/stats.rs
@@ -4,6 +4,7 @@ use crate::api::{
     bunpro::data::BunproReviewStats,
     cacheable::{CacheKey, Cacheable},
 };
+use anyhow::anyhow;
 use async_trait::async_trait;
 use reqwest::{header, Client};
 
@@ -18,7 +19,9 @@ impl Cacheable for BunproReviewStats {
     }
 
     async fn api_fetch() -> anyhow::Result<Self> {
-        let client = bunpro_client()?;
+        let frontend_session_cookie = get_frontend_auth_token().await?;
+        let client = bunpro_stats_client(frontend_session_cookie)?;
+
         client
             .get("https://bunpro.jp/api/frontend/user_stats/review_activity")
             .send()
@@ -30,15 +33,47 @@ impl Cacheable for BunproReviewStats {
     }
 }
 
-fn bunpro_client() -> anyhow::Result<Client> {
-    let bunpro_cookie = env::var("BUNPRO_COOKIE")?;
+fn bunpro_stats_client(frontend_session_token: String) -> anyhow::Result<Client> {
     let mut headers = reqwest::header::HeaderMap::new();
     headers.insert(
         header::AUTHORIZATION,
-        format!("Token token={}", bunpro_cookie).parse().unwrap(),
+        format!("Token {}", frontend_session_token).parse().unwrap(),
     );
 
     Ok(Client::builder().default_headers(headers).build()?)
+}
+
+async fn get_frontend_auth_token() -> anyhow::Result<String> {
+    const TOKEN_NAME: &str = "frontend_api_token";
+
+    let bunpro_grammar_cookie = env::var("BUNPRO_GRAMMAR_COOKIE")?;
+
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        header::COOKIE,
+        format!("_grammar_app_session={}", bunpro_grammar_cookie).parse()?,
+    );
+
+    let client = Client::builder()
+        .default_headers(headers)
+        .redirect(reqwest::redirect::Policy::none())
+        .build()?;
+
+    let bunpro_login = client
+        .get("https://bunpro.jp/login")
+        .send()
+        .await?
+        .error_for_status()?;
+
+    let cookie = bunpro_login.cookies().find_map(|cookie| {
+        if cookie.name() == TOKEN_NAME {
+            Some(cookie.value().to_string())
+        } else {
+            None
+        }
+    });
+
+    cookie.ok_or(anyhow!("frontend_app_session cookie could not be found"))
 }
 
 fn serialize_stats_response(body: String) -> anyhow::Result<BunproReviewStats> {


### PR DESCRIPTION
I didn't realise when I added the frontend_api_token that it was a session token, so it's going to expire quickly. To get around this I'm now going through the login API to collect a new token. Unfortunately I have to rely on the _grammar_app_session cookie, which is also session based. If that also expires too quick then I'll have to try and figure out a more permanent solution.