### PR TITLE
Add daily study goal for Anki

### DIFF
--- a/backend/src/api/anki/data.rs
+++ b/backend/src/api/anki/data.rs
@@ -9,6 +9,7 @@ pub struct AnkiData {
     new_card_count: u32,
     total_new_card_count: u32,
     data_updated_at: DateTime<Utc>,
+    daily_study_goal_meet: bool,
 }
 
 impl From<DeckInfo> for AnkiData {
@@ -19,6 +20,7 @@ impl From<DeckInfo> for AnkiData {
             new_card_count: deck.new_card_count(),
             total_new_card_count: deck.uncapped_new_card_count(),
             data_updated_at: Utc::now(),
+            daily_study_goal_meet: deck.review_card_count() == 0,
         }
     }
 }


### PR DESCRIPTION
Currently there's no way to know if I've done any study in a given day so I'm just checking whether the review queue is empty. I don't think I've had a day since I started where I didn't have at least 1 card to review, so it should be a decent indicator for now.