### PR TITLE
Bump images to latest versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
     # See: https://circleci.com/docs/configuration-reference/#executor-job
     docker:
-      - image: rust:1.71
+      - image: rust:1.74
     # Add steps to the job
     # See: https://circleci.com/docs/configuration-reference/#steps
     steps:
@@ -21,7 +21,7 @@ jobs:
           working_directory: "backend"
   backend lint:
     docker:
-      - image: rust:1.71
+      - image: rust:1.74
     steps:
         - checkout
         - run:
@@ -32,7 +32,7 @@ jobs:
             working_directory: "backend"
   backend test:
     docker:
-      - image: rust:1.71
+      - image: rust:1.74
     steps:
       - checkout
       - run:
@@ -43,7 +43,7 @@ jobs:
   # frontend
   frontend lint:
     docker:
-      - image: node:20.2.0
+      - image: node:20.10.0
     steps:
       - checkout
       - run:
@@ -54,7 +54,7 @@ jobs:
           working_directory: frontend
   frontend unit test:
     docker:
-        - image: node:20.2.0
+        - image: node:20.10.0
     steps:
       - checkout
       - run:
@@ -65,7 +65,7 @@ jobs:
           working_directory: frontend
   frontend type check:
     docker:
-        - image: node:20.2.0
+        - image: node:20.10.0
     steps:
       - checkout
       - run:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ############################
 # Backend build
 ############################
-FROM rust:1.71-alpine3.18 AS backend-build
+FROM rust:1.74-alpine3.18 AS backend-build
 
 RUN apk add pkgconfig openssl openssl-dev musl musl-dev
 
@@ -15,7 +15,7 @@ RUN cargo build --release
 ############################
 # Frontend build
 ############################
-FROM node:20.2.0-bullseye-slim AS frontend-build
+FROM node:20.10.0 AS frontend-build
 
 RUN mkdir /app
 WORKDIR /app

--- a/backend/dev.Dockerfile
+++ b/backend/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.71
+FROM rust:1.74
 
 RUN mkdir /app
 WORKDIR /app

--- a/frontend/dev.Dockerfile
+++ b/frontend/dev.Dockerfile
@@ -1,6 +1,4 @@
-# Needed to specifically lock to this version due to an ETXTBUSY issue with ESBuild
-# https://stackoverflow.com/questions/76461515/etxtbsy-error-when-installing-esbuild-in-docker-container
-FROM node:20.2.0-bullseye-slim
+FROM node:20.10.0
 
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
going to Rust 1.74 and Nodejs 20.10