### PR TITLE
Change redis return value to be Option

### DIFF
--- a/backend/src/api/cacheable.rs
+++ b/backend/src/api/cacheable.rs
@@ -99,17 +99,16 @@ pub trait Cacheable: DeserializeOwned + serde::Serialize {
             .await
             .map_err(Self::cache_log)
             .ok()?;
-        let cached_data: String = conn
-            .get(Self::cache_key())
+        let cached_data = conn
+            .get::<CacheKey, Option<String>>(Self::cache_key())
             .await
             .map_err(Self::cache_log)
-            .ok()?;
+            .ok()
+            .flatten()?;
 
-        let wanikani_data = serde_json::from_str::<Self>(&cached_data)
+        serde_json::from_str::<Self>(&cached_data)
             .map_err(Self::cache_log)
-            .ok()?;
-
-        Some(wanikani_data)
+            .ok()
     }
 
     async fn cache_write(


### PR DESCRIPTION
Because the keys are set with a TTL after they expire the fetch request will return nothing. However, since I defined the return type as a String this was causing an error.

This PR doesn't actually change behaviour as caching is designed to be optional so any cache errors are silently ignored, but it brings the type signature in line with reality.