### PR TITLE
Bump alpine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,15 @@ jobs:
             npm run type-check
           working_directory: frontend
 
+  production build:
+    docker:
+      - image: cimg/base:2023.06
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run: docker build .
+
   deploy:
     docker:
       - image: cimg/base:2023.06
@@ -95,6 +104,7 @@ workflows:
       - frontend lint
       - frontend unit test
       - frontend type check
+      - production build
       - deploy:
           requires:
             - backend build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ############################
 # Backend build
 ############################
-FROM rust:1.80-alpine3.18 AS backend-build
+FROM rust:1.80-alpine3.19 AS backend-build
 
 RUN apk add pkgconfig openssl openssl-dev musl musl-dev
 
@@ -28,7 +28,7 @@ RUN npm run build-only
 ############################
 # Executable
 ############################
-FROM alpine:3.18
+FROM alpine:3.19
 
 RUN apk add libc6-compat
 


### PR DESCRIPTION
Rust 1.80 doesn't have an alpine3.18 version. Also adding a build step for the production dockerfile since it would've caught it in the previous PR.