### PR TITLE
Require the production build step to complete before starting deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,7 @@ workflows:
             - frontend lint
             - frontend unit test
             - frontend type check
+            - production build
           filters:
             branches:
               only:


### PR DESCRIPTION
This was an oversight when I added the prod build step, we should ensure that the production container can successfully build before attempting to deploy.